### PR TITLE
GraphQL endpoint refactor

### DIFF
--- a/lib/schema.ex
+++ b/lib/schema.ex
@@ -29,13 +29,58 @@ defmodule MusicApp.Schema do
     field :album, :album
   end
 
+  def order_by_name(query, field_name) do
+    query |> order_by([m], field(m, field_name))
+  end
+
+  def filter_after(query, cursor) do
+    [field_name, val] = decode_cursor(cursor)
+    query |> where([m], field(m, field_name) > val)
+  end
+
+  def connection_query(base_query, opts \\ []) do
+    opts = case opts[:order_by] do
+      atom when is_atom(atom) ->
+        opts
+      str when is_binary(str) ->
+        %{opts | order_by: String.to_existing_atom(str)}
+    end
+
+    edges = 
+      base_query
+      |> filter_order_by(opts[:order_by])
+      |> filter_after(opts[:after])
+      |> limit(opts[:limit])
+      |> Repo.all
+      |> Enum.map(fn node ->
+        field_name = opts[:order_by]
+        val = Map.get(node, field_name)
+
+        [
+          {:cursor, encode_cursor(field_name, val)},
+          {node_name, node}
+        ]
+        |> Enum.into(%{})
+      end)
+
+    end_cursor = edges |> Enum.map(&Map.fetch!(&1, :cursor)) |> List.last
+
+    %{end_cursor: end_cursor, edges: edges}
+  end
+
+  def fetch_connection(node_name, base_query, opts \\ []) do
+  end
+
   query do
     field :artists, :artist_connection do
       arg :limit, :integer
       arg :after, :string
 
       resolve fn args, _ctx ->
-        limit = args[:limit] || 50
+        args =
+          args
+          |> Map.put_new(:limit, 50)
+          |> Map.put_new(:order_by, "name")
 
         query = 
           from(
@@ -44,31 +89,10 @@ defmodule MusicApp.Schema do
             distinct: true,
             select: artist,
             where: album.artist_id == artist.id,
-            limit: ^limit, 
-            order_by: artist.name
           )
-          
-        query =
-          if args[:after] do
-            {:ok, [key, name]} = decode_cursor(args[:after])
-            query |> where([a], a.name > ^name)
-          else
-            query
-          end
-            
-          edges = 
-            query
-            |> Repo.all
-            |> Enum.map(fn artist ->
-              %{cursor: encode_cursor(:name, artist.name), artist: artist}
-            end)
 
-        end_cursor = 
-          edges 
-          |> Enum.map(&Map.fetch!(&1, :cursor))
-          |> List.last
-
-        {:ok, %{edges: edges, end_cursor: end_cursor}}
+        results = connection_query(:artist, query, args)
+        {:ok, results}
       end
     end
 


### PR DESCRIPTION
# Ideas

## Generic Connection Object

Similar to a `field` or a `query` object, we should have a simple way to define a `connection_field` object. This should define generic connection field arguments such as `limit`, `order_by`, and `after`.

### Usage
```elixir

@sortable_fields [:name, :created_at]
connection_query :artists, :artist do
end
```